### PR TITLE
feat(core): split prepare method for begin process and record process

### DIFF
--- a/SkyFrost/Module/Commands/Abstract/ResoniteConnectedCmdlet.cs
+++ b/SkyFrost/Module/Commands/Abstract/ResoniteConnectedCmdlet.cs
@@ -16,11 +16,12 @@ public class ResoniteConnectedCmdlet : BasePSCmdlet
     [Parameter(HelpMessage = "Optional client to be used. Defaults to the default current client if null.")]
     public ISkyFrostInterfaceClient? Client;
 
-    protected override void PrepareCmdlet()
+    protected override void PerformPreprocessSetup()
     {
         if (Client == null)
         {
-            Client = SkyFrostInterfacePool.Current ?? throw new InvalidOperationException("A client has not been established yet. Use Connect-ResoniteConnectApi to connect or provide a valid client using -Client.");
+            Client = SkyFrostInterfacePool.Current
+                ?? throw new InvalidOperationException("A client has not been established yet. Use Connect-ResoniteConnectApi to connect or provide a valid client using -Client.");
         }
     }
 }


### PR DESCRIPTION
Split the preparation method into two:

* `PerformPreprocessSetup` will be called during the begin process phase.
* `PrepareCmdlet` will be called during the process phase (i.e., record process).

This should help prevent the issue of preparing the cmdlet when the values from the pipebind are not available since values from pipebind are not during the begin process phase.