### PR TITLE
feat(sf): change cmdlet name prefix to sf

### DIFF
--- a/SkyFrost/Module/Commands/Abstract/SkyFrostAssetInfoCmdlet.cs
+++ b/SkyFrost/Module/Commands/Abstract/SkyFrostAssetInfoCmdlet.cs
@@ -8,7 +8,7 @@ using Core.Models.Abstract;
 /// <summary>
 /// Base class for cmdlets that require an AssetInfo object or hash id string.
 /// </summary>
-public abstract class ResoniteAssetInfoCmdlet : ResoniteConnectedCmdlet
+public abstract class SkyFrostAssetInfoCmdlet : SkyFrostConnectedCmdlet
 {
     /// <summary>
     /// AssetInfo object or hash id string representing the asset.
@@ -21,9 +21,9 @@ public abstract class ResoniteAssetInfoCmdlet : ResoniteConnectedCmdlet
     /// </summary>
     public string HashId => AssetInfo.HashId;
 
-    public ResoniteAssetInfoCmdlet() : base() { }
+    public SkyFrostAssetInfoCmdlet() : base() { }
 
-    public ResoniteAssetInfoCmdlet(IFileSystem fileSystem) : base(fileSystem) { }
+    public SkyFrostAssetInfoCmdlet(IFileSystem fileSystem) : base(fileSystem) { }
 
     /// <summary>
     /// Prepares the cmdlet for execution by performing necessary validation and setup.

--- a/SkyFrost/Module/Commands/Abstract/SkyFrostConnectedCmdlet.cs
+++ b/SkyFrost/Module/Commands/Abstract/SkyFrostConnectedCmdlet.cs
@@ -7,26 +7,26 @@ using Core.Commands.Abstract;
 using Core.Models.Abstract;
 
 /// <summary>
-/// Base class for cmdlets that require a Resonite connection
+/// Base class for cmdlets that require a SkyFrost connection.
 /// </summary>
-public class ResoniteConnectedCmdlet : BasePSCmdlet
+public class SkyFrostConnectedCmdlet : BasePSCmdlet
 {
     /// <summary>
-    /// Client to use for Resonite Api calls
+    /// Client to use for SkyFrost Api calls
     /// </summary>
     [Parameter(HelpMessage = "Optional client to be used. Defaults to the default current client if null.")]
     public ISkyFrostInterfaceClient? Client;
 
-    public ResoniteConnectedCmdlet() : base() { }
+    public SkyFrostConnectedCmdlet() : base() { }
 
-    public ResoniteConnectedCmdlet(IFileSystem fileSystem) : base(fileSystem) { }
+    public SkyFrostConnectedCmdlet(IFileSystem fileSystem) : base(fileSystem) { }
 
     protected override void PerformPreprocessSetup()
     {
         if (Client == null)
         {
             Client = SkyFrostInterfacePool.Current
-                ?? throw new InvalidOperationException("A client has not been established yet. Use Connect-ResoniteConnectApi to connect or provide a valid client using -Client.");
+                ?? throw new InvalidOperationException("A client has not been established yet. Use Connect-SfConnectApi to connect or provide a valid client using -Client.");
         }
     }
 }

--- a/SkyFrost/Module/Commands/Abstract/SkyFrostOwnerResourceCmdlet.cs
+++ b/SkyFrost/Module/Commands/Abstract/SkyFrostOwnerResourceCmdlet.cs
@@ -5,25 +5,25 @@ namespace Jworkz.ResonitePowerShellModule.SkyFrost.Commands.Abstract;
 
 using PipeBinds;
 
-public abstract class ResoniteOwnerResourceCmdlet : ResoniteConnectedCmdlet
+public abstract class SkyFrostOwnerResourceCmdlet : SkyFrostConnectedCmdlet
 {
     /// <summary>
-    /// Owner of the resource
+    /// Owner of the resource.
     /// </summary>
     public virtual OwnerPipeBind? Owner { get; set; }
 
     /// <summary>
-    /// Id of the owner
+    /// Id of the owner.
     /// </summary>
     public string OwnerId => Owner?.OwnerId ?? string.Empty;
 
     /// <summary>
-    /// User type of the owner
+    /// User type of the owner.
     /// </summary>
     public OwnerTypeEnum OwnerType => Owner?.OwnerType ?? OwnerTypeEnum.INVALID;
 
     /// <summary>
-    /// Ensure the owner is either a user or group type
+    /// Ensure the owner is either a user or group type.
     /// </summary>
     /// <exception cref="PSInvalidOperationException"></exception>
     protected override void ExecuteCmdlet()

--- a/SkyFrost/Module/Commands/Assets/GetAssetGather.cs
+++ b/SkyFrost/Module/Commands/Assets/GetAssetGather.cs
@@ -12,10 +12,10 @@ using Commands.Abstract;
 using PipeBinds;
 
 /// <summary>
-/// Retrieves an asset blob from Resonite
+/// Retrieves an asset blob from SkyFrost.
 /// </summary>
-[Cmdlet(VerbsCommon.Get, "ResoniteAssetGather", DefaultParameterSetName = PARAM_SET_SAVEFILE)]
-public sealed class GetAssetGather : ResoniteAssetInfoCmdlet
+[Cmdlet(VerbsCommon.Get, "SfAssetGather", DefaultParameterSetName = PARAM_SET_SAVEFILE)]
+public sealed class GetAssetGather : SkyFrostAssetInfoCmdlet
 {
     private const string PARAM_SET_SAVEFILE = "Save asset to local path";
     private const string PARAM_SET_SAVEFILEPIPEBIND = "Save asset from pipebind to local path";

--- a/SkyFrost/Module/Commands/Assets/GetAssetInfo.cs
+++ b/SkyFrost/Module/Commands/Assets/GetAssetInfo.cs
@@ -10,8 +10,8 @@ using SkyFrost.PipeBinds;
 /// Retrieves information about an asset from SkyFrost based on its hash id or 
 /// AssetInfo object.
 /// </summary>
-[Cmdlet(VerbsCommon.Get, "ResoniteAssetInfo", DefaultParameterSetName = PARAM_SET_GETOWNEDASSET)]
-public class GetAssetInfo : ResoniteAssetInfoCmdlet
+[Cmdlet(VerbsCommon.Get, "SfAssetInfo", DefaultParameterSetName = PARAM_SET_GETOWNEDASSET)]
+public class GetAssetInfo : SkyFrostAssetInfoCmdlet
 {
     private const string PARAM_SET_GETOWNEDASSET = "Without a pipebind, get asset based on Owned Route";
     private const string PARAM_SET_GETOWNEDASSETPIPEBIND = "With a pipebind, get asset based on Owned Route";

--- a/SkyFrost/Module/Commands/Assets/GetAssetMime.cs
+++ b/SkyFrost/Module/Commands/Assets/GetAssetMime.cs
@@ -8,8 +8,8 @@ using Core.Utilities;
 /// <summary>
 /// Retrieves the MIME type of an asset from SkyFrost based on its hash id.
 /// </summary>
-[Cmdlet(VerbsCommon.Get, "ResoniteAssetMime")]
-public class GetAssetMime : ResoniteAssetInfoCmdlet
+[Cmdlet(VerbsCommon.Get, "SfAssetMime")]
+public class GetAssetMime : SkyFrostAssetInfoCmdlet
 {
     /// <summary>
     /// Executes the cmdlet to retrieve the MIME type of the asset based on the specified hash id.

--- a/SkyFrost/Module/Commands/Assets/GetAssetVariant.cs
+++ b/SkyFrost/Module/Commands/Assets/GetAssetVariant.cs
@@ -8,8 +8,8 @@ using Core.Utilities;
 /// <summary>
 /// Retrieves all available variants for a specific asset from SkyFrost based on its hash id.
 /// </summary>
-[Cmdlet(VerbsCommon.Get, "ResoniteAssetVariant")]
-public class GetAssetVariant : ResoniteAssetInfoCmdlet
+[Cmdlet(VerbsCommon.Get, "SfAssetVariant")]
+public class GetAssetVariant : SkyFrostAssetInfoCmdlet
 {
     /// <summary>
     /// Executes the cmdlet to retrieve all available asset variants based on the specified hash id.

--- a/SkyFrost/Module/Commands/Connection/ConnectApi.cs
+++ b/SkyFrost/Module/Commands/Connection/ConnectApi.cs
@@ -11,9 +11,9 @@ using Clients;
 using Clients.Abstract;
 
 /// <summary>
-/// Connects to the Resonite Api interface via SkyFrost with either the default or provided Uris
+/// Connects to the SkyFrost Api interface with either the default or provided Uris
 /// </summary>
-[Cmdlet("Connect", "ResoniteApi", DefaultParameterSetName = PARAM_SET_CREDENTIALONLY)]
+[Cmdlet("Connect", "SfApi", DefaultParameterSetName = PARAM_SET_CREDENTIALONLY)]
 [OutputType([typeof(ISkyFrostInterfaceClient), typeof(void)])]
 public class ConnectApi : BasePSCmdlet
 {
@@ -25,7 +25,7 @@ public class ConnectApi : BasePSCmdlet
     private static readonly string _productVersion;
 
     /// <summary>
-    /// Resonite credential to use with the SkyfrostInterface client
+    /// SkyFrost credential (usually a Resonite credential) to use with the SkyfrostInterface client
     /// </summary>
     [Parameter(Mandatory = true, ParameterSetName = PARAM_SET_CREDENTIALONLY, Position = 0)]
     public PSCredential? Credential { get; set; }

--- a/SkyFrost/Module/Commands/Connection/DisconnectApi.cs
+++ b/SkyFrost/Module/Commands/Connection/DisconnectApi.cs
@@ -6,9 +6,9 @@ using Core.Commands.Abstract;
 using Clients.Abstract;
 
 /// <summary>
-/// Disconnects from the Resonite Api interface via CloudX with either the default or provided client
+/// Disconnects from the SkyFrost Api interface with either the default or provided client
 /// </summary>
-[Cmdlet("Disconnect", "ResoniteApi")]
+[Cmdlet("Disconnect", "SfApi")]
 [OutputType(typeof(void))]
 public class DisconnectApi : BasePSCmdlet
 {

--- a/SkyFrost/Module/Commands/Connection/GetCurrentClient.cs
+++ b/SkyFrost/Module/Commands/Connection/GetCurrentClient.cs
@@ -5,9 +5,9 @@ namespace Jworkz.ResonitePowerShellModule.SkyFrost.Commands.Connection;
 using Core.Commands.Abstract;
 
 /// <summary>
-/// Retrieves the current CloudX client used as the default client
+/// Retrieves the current SkyFrost client used as the default client.
 /// </summary>
-[Cmdlet(VerbsCommon.Get, "ResoniteCurrentSkyFrostClient")]
+[Cmdlet(VerbsCommon.Get, "SfCurrentClient")]
 public class GetCurrentClient : BasePSCmdlet
 {
     protected override void ExecuteCmdlet()

--- a/SkyFrost/Module/Commands/Connection/GetSkyFrostConfig.cs
+++ b/SkyFrost/Module/Commands/Connection/GetSkyFrostConfig.cs
@@ -15,9 +15,9 @@ using Core.Utilities;
 using Core.Models.Abstract;
 
 /// <summary>
-/// Loads a SkyFrost configration that can be used to setup a SkyFrost client
+/// Loads a SkyFrost configration that can be used to setup a SkyFrost client.
 /// </summary>
-[Cmdlet(VerbsCommon.Get, "ResoniteSkyFrostConfig")]
+[Cmdlet(VerbsCommon.Get, "SfConfig")]
 [OutputType(typeof(SkyFrostConfig))]
 public class GetSkyFrostConfig : BasePSCmdlet
 {

--- a/SkyFrost/Module/Commands/Connection/PingApi.cs
+++ b/SkyFrost/Module/Commands/Connection/PingApi.cs
@@ -6,10 +6,10 @@ using Commands.Abstract;
 using Core.Utilities;
 
 /// <summary>
-/// Pings the Resonite Api interface
+/// Pings the SkyFrost Api interface.
 /// </summary>
-[Cmdlet(VerbsCommon.Get, "ResonitePing")]
-public class PingApi : ResoniteConnectedCmdlet
+[Cmdlet(VerbsCommon.Get, "SfPing")]
+public class PingApi : SkyFrostConnectedCmdlet
 {
     protected override void ExecuteCmdlet()
     {

--- a/SkyFrost/Module/Commands/Principal/GetCurrentUser.cs
+++ b/SkyFrost/Module/Commands/Principal/GetCurrentUser.cs
@@ -5,10 +5,10 @@ namespace Jworkz.ResonitePowerShellModule.SkyFrost.Commands.Principal;
 using Commands.Abstract;
 
 /// <summary>
-/// Retrieves the current Resonite user who had connected to the cloud using this interface
+/// Retrieves the current user who had connected to the SkyFrost infrastructure using this interface.
 /// </summary>
-[Cmdlet(VerbsCommon.Get, "ResoniteCurrentUser")]
-public class GetCurrentUser : ResoniteConnectedCmdlet
+[Cmdlet(VerbsCommon.Get, "SfCurrentUser")]
+public class GetCurrentUser : SkyFrostConnectedCmdlet
 {
     protected override void ExecuteCmdlet()
     {

--- a/SkyFrost/Module/Commands/Records/GetRecordById.cs
+++ b/SkyFrost/Module/Commands/Records/GetRecordById.cs
@@ -8,13 +8,13 @@ using Core.Utilities;
 using SkyFrost.PipeBinds;
 
 /// <summary>
-/// Retrieves the record object by record id
+/// Retrieves the record object by record id.
 /// </summary>
-[Cmdlet(VerbsCommon.Get, "ResoniteRecordById")]
-public class GetRecordById : ResoniteConnectedCmdlet
+[Cmdlet(VerbsCommon.Get, "SfRecordById")]
+public class GetRecordById : SkyFrostConnectedCmdlet
 {
     /// <summary>
-    /// Record id of the record object
+    /// Record id of the record object.
     /// </summary>
     [Parameter(Mandatory = true, ValueFromPipeline = true)]
     public RecordIdPipeBind? RecordId;

--- a/SkyFrost/Module/Commands/Records/GetRecordByOwner.cs
+++ b/SkyFrost/Module/Commands/Records/GetRecordByOwner.cs
@@ -10,9 +10,9 @@ using PipeBinds;
 /// <summary>
 /// Retrieves records associated by the Owner
 /// </summary>
-[Cmdlet(VerbsCommon.Get, "ResoniteRecordByOwner", DefaultParameterSetName = PARAM_SET_RECORDSPATHFILTER)]
+[Cmdlet(VerbsCommon.Get, "SfRecordByOwner", DefaultParameterSetName = PARAM_SET_RECORDSPATHFILTER)]
 [OutputType(typeof(Record))]
-public class GetRecordByOwner : ResoniteOwnerResourceCmdlet
+public class GetRecordByOwner : SkyFrostOwnerResourceCmdlet
 {
     private const string PARAM_SET_RECORDSPATHFILTER = "Filter records by path";
     private const string PARAM_SET_RECORDSPATHFILTERINCLUDINGHIERARCHY = "Filter records by path (include the hierarchy)";

--- a/SkyFrost/Test/Commands/Abstract/ResoniteAssetInfoCmdletUnitTest.cs
+++ b/SkyFrost/Test/Commands/Abstract/ResoniteAssetInfoCmdletUnitTest.cs
@@ -47,23 +47,23 @@ public class ResoniteAssetInfoCmdletUnitTest
     public void CreateCmd_FileSystemDI_UsesCustomFileSystem()
     {
         var fileSystemMock = new Mock<IFileSystem>();
-        var cmdlet = new Mock<ResoniteAssetInfoCmdlet>(fileSystemMock.Object) { CallBase = true }.Object;
+        var cmdlet = new Mock<SkyFrostAssetInfoCmdlet>(fileSystemMock.Object) { CallBase = true }.Object;
         Assert.Equal(fileSystemMock.Object, cmdlet.FileSystem);
     }
 
     /// <summary>
-    /// Configures and returns a mock instance of the <see cref="ResoniteAssetInfoCmdlet"/> class for testing purposes.
+    /// Configures and returns a mock instance of the <see cref="SkyFrostAssetInfoCmdlet"/> class for testing purposes.
     /// </summary>
     /// <param name="assetInfoPipeBindMock">A mock implementation of <see cref="AssetInfoPipeBind"/> to be assigned to the <see
-    /// cref="ResoniteAssetInfoCmdlet.AssetInfo"/> property.</param>
+    /// cref="SkyFrostAssetInfoCmdlet.AssetInfo"/> property.</param>
     /// <param name="callBase">A value indicating whether the base class implementation of the mocked cmdlet should be called.  Defaults to
     /// <see langword="true"/>.</param>
-    /// <returns>A fully configured mock instance of <see cref="ResoniteAssetInfoCmdlet"/> with its properties and dependencies
+    /// <returns>A fully configured mock instance of <see cref="SkyFrostAssetInfoCmdlet"/> with its properties and dependencies
     /// set up.</returns>
-    private static ResoniteAssetInfoCmdlet SetupCmdlet(AssetInfoPipeBind assetInfoPipeBindMock, bool callBase = true)
+    private static SkyFrostAssetInfoCmdlet SetupCmdlet(AssetInfoPipeBind assetInfoPipeBindMock, bool callBase = true)
     {
         Mock<ISkyFrostInterfaceClient> skyFrostClientMock = new();
-        Mock<ResoniteAssetInfoCmdlet> cmdletMock = new();
+        Mock<SkyFrostAssetInfoCmdlet> cmdletMock = new();
         cmdletMock.CallBase = callBase;
 
         var cmdlet = cmdletMock.Object;

--- a/SkyFrost/Test/Commands/Abstract/ResoniteOwnerResourceCmdletUnitTest.cs
+++ b/SkyFrost/Test/Commands/Abstract/ResoniteOwnerResourceCmdletUnitTest.cs
@@ -44,10 +44,10 @@ public class ResoniteOwnerResourceCmdletUnitTest
     /// <param name="ownerMock">The owner pipebind mock.</param>
     /// <param name="callBase">true if base calls should be performed; otherwise, false.</param>
     /// <returns></returns>
-    private static ResoniteOwnerResourceCmdlet SetupCmdlet(OwnerPipeBind? ownerMock, bool callBase = true)
+    private static SkyFrostOwnerResourceCmdlet SetupCmdlet(OwnerPipeBind? ownerMock, bool callBase = true)
     {
         Mock<ISkyFrostInterfaceClient> skyFrostClientMock = new();
-        Mock<ResoniteOwnerResourceCmdlet> cmdletMock = new();
+        Mock<SkyFrostOwnerResourceCmdlet> cmdletMock = new();
         cmdletMock.CallBase = callBase;
         cmdletMock.SetupAllProperties();
 


### PR DESCRIPTION
This PR changes the prefix cmdlet name for all the SkyFrost cmdlets from `Resonite` to `SF`. Additionally, all previous names that used `Resonite` in them have been changed to `SkyFrost`; this mainly happened for classes that used the name `Resonite`.